### PR TITLE
Slot Extender cleanup

### DIFF
--- a/SlotExtender/Initialize_uGUI.cs
+++ b/SlotExtender/Initialize_uGUI.cs
@@ -12,38 +12,52 @@ namespace SlotExtender
 
         internal uGUI_EquipmentSlot temp_slot;
 
+        private const float Unit = 145f;
+
+        private const float TopRow = Unit;
+        private const float MiddleRow = 0f;
+        private const float BottomRow = -Unit;
+
+        private const float CenterOddColumn = 0f;
+        private const float OutsideRightOddColumn = Unit;
+        private const float OutsideRightEvenColumn = OutsideRightOddColumn * 1.5f;
+        private const float InsideRightEvenColumn = OutsideRightEvenColumn / 3f;
+        private const float InsideLeftEvenColumn = -InsideRightEvenColumn;
+        private const float OutsideLeftEvenColumn = -OutsideRightEvenColumn;
+        private const float OutsideLeftOddColumn = -OutsideRightOddColumn;
+
         internal static readonly Vector2[] seamoth_slotPos = new Vector2[9]
         {
-            new Vector2(143f, -149f),   //slot 1
-            new Vector2(0f, -149f),     //slot 2
-            new Vector2(-143f, -149f),  //slot 3
+            new Vector2(OutsideRightEvenColumn, BottomRow), //slot 1
+            new Vector2(InsideRightEvenColumn, BottomRow),  //slot 2
+            new Vector2(InsideLeftEvenColumn, BottomRow),   //slot 3
+            new Vector2(OutsideLeftEvenColumn, BottomRow),  //slot 4
 
-            new Vector2(143f, -6.5f),   //slot 4
-            new Vector2(0f, -6.5f),     //slot 5
-            new Vector2(-143f, -6.5f),  //slot 6
+            new Vector2(OutsideRightOddColumn, MiddleRow), //slot 5
+            new Vector2(CenterOddColumn, MiddleRow),       //slot 6
+            new Vector2(OutsideLeftOddColumn, MiddleRow),  //slot 7
 
-            new Vector2(143f, 136f),    //slot 7
-            new Vector2(0f, 136f),      //slot 8
-            new Vector2(-143f, 136f)    //slot 9
+            new Vector2(InsideLeftEvenColumn, TopRow),  //slot 8
+            new Vector2(InsideRightEvenColumn, TopRow),   //slot 9
         };
 
         internal static readonly Vector2[] exosuit_slotPos = new Vector2[8]
         {
-            new Vector2(-143f, 136f),   //slot 1
-            new Vector2(0f, 136f),      //slot 2
-            new Vector2(143f, 136f),    //slot 3
+            new Vector2(OutsideLeftOddColumn, TopRow),  //slot 1
+            new Vector2(CenterOddColumn, TopRow),       //slot 2
+            new Vector2(OutsideRightOddColumn, TopRow), //slot 3
 
-            new Vector2(-80, -5.5f),    //slot 4
-            new Vector2(80, -5.5f),     //slot 5
+            new Vector2(InsideLeftEvenColumn, MiddleRow),  //slot 4
+            new Vector2(InsideRightEvenColumn, MiddleRow), //slot 5
 
-            new Vector2(-143f, -149f),  //slot 6
-            new Vector2(0f, -149f),     //slot 7
-            new Vector2(143f, -149f)    //slot 8            
+            new Vector2(OutsideLeftOddColumn, BottomRow), //slot 6
+            new Vector2(CenterOddColumn, BottomRow),      //slot 7
+            new Vector2(OutsideRightOddColumn, BottomRow) //slot 8
         };
 
         internal void Awake()
         {
-            Instance = this;            
+            Instance = this;
         }
 
         internal void Add_uGUIslots(uGUI_Equipment instance, Dictionary<string, uGUI_EquipmentSlot> allSlots)
@@ -52,42 +66,46 @@ namespace SlotExtender
             {
                 foreach (uGUI_EquipmentSlot slot in instance.GetComponentsInChildren<uGUI_EquipmentSlot>(true))
                 {
-                    //always slot1 includes the background image, therefore instantiate the slot2 for avoid duplicates
+                    // slot1 always includes the background image, therefore instantiate the slot2 to avoid duplicate background images
                     if (slot.name == "SeamothModule2")
                     {
                         for (int i = 4; i < SlotHelper.ExpandedSeamothSlotIDs.Length; i++)
                         {
                             temp_slot = Instantiate(slot, slot.gameObject.transform.parent);
                             temp_slot.name = SlotHelper.ExpandedSeamothSlotIDs[i];
-                            temp_slot.slot = SlotHelper.ExpandedSeamothSlotIDs[i];                                                        
+                            temp_slot.slot = SlotHelper.ExpandedSeamothSlotIDs[i];
                             allSlots.Add(SlotHelper.ExpandedSeamothSlotIDs[i], temp_slot);
-                        }                        
+                        }
+
+                        break;
                     }
-                    
-                    if (slot.name == "ExosuitModule2")
+                    else if (slot.name == "ExosuitModule2")
                     {
                         for (int i = 6; i < SlotHelper.ExpandedExosuitSlotIDs.Length; i++)
                         {
                             temp_slot = Instantiate(slot, slot.gameObject.transform.parent);
                             temp_slot.name = SlotHelper.ExpandedExosuitSlotIDs[i];
-                            temp_slot.slot = SlotHelper.ExpandedExosuitSlotIDs[i];                            
+                            temp_slot.slot = SlotHelper.ExpandedExosuitSlotIDs[i];
                             allSlots.Add(SlotHelper.ExpandedExosuitSlotIDs[i], temp_slot);
-                        }                        
-                    }                    
+                        }
+
+                        break;
+                    }
                 }
-                
+
                 foreach (KeyValuePair<string, uGUI_EquipmentSlot> item in allSlots)
                 {
-                    if (item.Value.name.Contains("SeamothModule"))
-                    {                        
-                        int.TryParse(item.Key.Substring(13, 1), out int slotNum);
+                    if (item.Value.name.StartsWith("SeamothModule"))
+                    {
+                        int.TryParse(item.Key.Substring(13), out int slotNum);
                         item.Value.rectTransform.anchoredPosition = seamoth_slotPos[slotNum - 1];
                         AddSlotNumbers(item.Value.gameObject.transform, slotNum.ToString());
+
                     }
 
-                    if (item.Value.name.Contains("ExosuitModule"))
+                    if (item.Value.name.StartsWith("ExosuitModule"))
                     {
-                        int.TryParse(item.Key.Substring(13, 1), out int slotNum);
+                        int.TryParse(item.Key.Substring(13), out int slotNum);
                         item.Value.rectTransform.anchoredPosition = exosuit_slotPos[slotNum - 1];
                         AddSlotNumbers(item.Value.gameObject.transform, slotNum.ToString());
                     }
@@ -118,7 +136,7 @@ namespace SlotExtender
             text.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 100);
             text.rectTransform.anchoredPosition = new Vector3(0, 70);
             text.alignment = TextAnchor.MiddleCenter;
-            text.raycastTarget = false;            
+            text.raycastTarget = false;
         }
     }
 }

--- a/SlotExtender/SlotExtender.cs
+++ b/SlotExtender/SlotExtender.cs
@@ -3,61 +3,48 @@ using UWE;
 
 namespace SlotExtender
 {
-    internal class SlotExtender : MonoBehaviour 
+    internal class SlotExtender : MonoBehaviour
     {
         public SlotExtender Instance { get; private set; }
         public Vehicle ThisVehicle { get; private set; }
 
         internal bool isOpen = false;
-        internal bool isActive = false;                
-
-        internal static readonly string[] newSeamothSlotIDs = new string[5]
-        {
-           "SeamothModule5",
-           "SeamothModule6",
-           "SeamothModule7",
-           "SeamothModule8",
-           "SeamothModule9"
-        };
-
-        internal static readonly string[] newExosuitSlotIDs = new string[4]
-        {
-           "ExosuitModule5",
-           "ExosuitModule6",
-           "ExosuitModule7",
-           "ExosuitModule8"
-        };        
+        internal bool isActive = false;
 
         internal void Awake()
         {
-            Instance = this;
-            
-            if (Instance.GetComponent<SeaMoth>())
+            this.Instance = this;
+
+            if (this.Instance.GetComponent<SeaMoth>())
             {
-                ThisVehicle = Instance.GetComponent<SeaMoth>();
-                ThisVehicle.modules.AddSlots(newSeamothSlotIDs);                
+                this.ThisVehicle = this.Instance.GetComponent<SeaMoth>();
+
+                foreach (string slotID in SlotHelper.NewSeamothSlotIDs)
+                    this.ThisVehicle.modules.AddSlot(slotID);
             }
             else
             {
-                ThisVehicle = Instance.GetComponent<Exosuit>();
-                ThisVehicle.modules.AddSlots(newExosuitSlotIDs);                
-            }            
+                this.ThisVehicle = this.Instance.GetComponent<Exosuit>();
+
+                foreach (string slotID in SlotHelper.NewExosuitSlotIDs)
+                    this.ThisVehicle.modules.AddSlot(slotID);
+            }
         }
-        
+
         internal void Start()
-        {  
+        {
             //forced triggering the Awake method in uGUI_Equipment for patching
             Player.main.GetPDA().Open();
             Player.main.GetPDA().Close();
 
-            Utils.GetLocalPlayerComp().playerModeChanged.AddHandler(gameObject, new Event<Player.Mode>.HandleFunction(OnPlayerModeChanged));
+            Utils.GetLocalPlayerComp().playerModeChanged.AddHandler(this.gameObject, new Event<Player.Mode>.HandleFunction(OnPlayerModeChanged));
         }
 
         internal void OnPlayerModeChanged(Player.Mode playerMode)
         {
             if (playerMode == Player.Mode.LockedPiloting)
             {
-                if (Player.main.GetVehicle() == ThisVehicle)
+                if (Player.main.GetVehicle() == this.ThisVehicle)
                 {
                     isActive = true;
                 }
@@ -74,53 +61,52 @@ namespace SlotExtender
 
         internal void Update()
         {
-            if (isActive)
+            if (!isActive)
+                return; // Slot Extender not active. Exit method.
+
+            if (!Player.main.inSeamoth && !Player.main.inExosuit)
+                return; // Player not in vehicle. Exit method.
+
+            if (Input.GetKeyDown(KeyCode.R))
             {
-                if (Player.main.inSeamoth || Player.main.inExosuit)
+                if (isOpen)
                 {
-                    if (Input.GetKeyDown(KeyCode.R) && !isOpen)
-                    {                       
-                        ThisVehicle.upgradesInput.OpenFromExternal();
-                        isOpen = true;
-                    }
-                    else if (isOpen && Input.GetKeyDown(KeyCode.R))
-                    {
-                        Player.main.GetPDA().Close();
-                        isOpen = false;
-                    }
-
-                    if (Input.GetKeyDown(KeyCode.Alpha6))
-                    {
-                        ThisVehicle.SendMessage("SlotKeyDown", 5);
-                    }
-
-                    if (Input.GetKeyDown(KeyCode.Alpha7))
-                    {
-                        ThisVehicle.SendMessage("SlotKeyDown", 6);
-                    }
-
-                    if (Input.GetKeyDown(KeyCode.Alpha8))
-                    {
-                        ThisVehicle.SendMessage("SlotKeyDown", 7);
-                    }
-
-                    if (Input.GetKeyDown(KeyCode.Alpha9))
-                    {
-                        ThisVehicle.SendMessage("SlotKeyDown", 8);
-                    }
+                    Player.main.GetPDA().Close();
+                    isOpen = false;
                 }
+                else // Is Closed
+                {
+                    this.ThisVehicle.upgradesInput.OpenFromExternal();
+                    isOpen = true;
+                }
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha6))
+            {
+                this.ThisVehicle.SendMessage("SlotKeyDown", 5);
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha7))
+            {
+                this.ThisVehicle.SendMessage("SlotKeyDown", 6);
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha8))
+            {
+                this.ThisVehicle.SendMessage("SlotKeyDown", 7);
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha9))
+            {
+                this.ThisVehicle.SendMessage("SlotKeyDown", 8);
             }
         }
 
         internal static bool IsExtendedSeamothSlot(string slotName)
         {
-            foreach (string slot in newSeamothSlotIDs)
+            foreach (string slot in SlotHelper.NewSeamothSlotIDs)
             {
                 if (slotName == slot)
                     return true;
             }
 
             return false;
-        }        
+        }
     }
 }

--- a/SlotExtender/SlotHelper.cs
+++ b/SlotExtender/SlotHelper.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 
 namespace SlotExtender
 {
@@ -12,11 +13,12 @@ namespace SlotExtender
             "SeamothModule2",
             "SeamothModule3",
             "SeamothModule4",
+            // New slots start here
             "SeamothModule5",
             "SeamothModule6",
             "SeamothModule7",
             "SeamothModule8",
-            "SeamothModule9"
+            "SeamothModule9",
         };
 
         internal static readonly string[] ExpandedExosuitSlotIDs = new string[10]
@@ -27,27 +29,45 @@ namespace SlotExtender
             "ExosuitModule2",
             "ExosuitModule3",
             "ExosuitModule4",
+            // New slots start here
             "ExosuitModule5",
             "ExosuitModule6",
             "ExosuitModule7",
             "ExosuitModule8"
         };
-        
+
+        internal static IEnumerable<string> NewSeamothSlotIDs
+        {
+            get
+            {
+                for (int i = 4; i < ExpandedSeamothSlotIDs.Length; i++)
+                {
+                    yield return ExpandedSeamothSlotIDs[i];
+                }
+            }
+        }
+
+        internal static IEnumerable<string> NewExosuitSlotIDs
+        {
+            get
+            {
+                for (int i = 6; i < ExpandedExosuitSlotIDs.Length; i++)
+                {
+                    yield return ExpandedExosuitSlotIDs[i];
+                }
+            }
+        }
+
         internal static void ExpandSlotMapping()
         {
             if (!SlotMappingExpanded)
             {
-                Equipment.slotMapping.Add("SeamothModule5", EquipmentType.SeamothModule);
-                Equipment.slotMapping.Add("SeamothModule6", EquipmentType.SeamothModule);
-                Equipment.slotMapping.Add("SeamothModule7", EquipmentType.SeamothModule);
-                Equipment.slotMapping.Add("SeamothModule8", EquipmentType.SeamothModule);
-                Equipment.slotMapping.Add("SeamothModule9", EquipmentType.SeamothModule);
+                foreach (string slotID in ExpandedSeamothSlotIDs)
+                    Equipment.slotMapping.Add(slotID, EquipmentType.SeamothModule);
 
-                Equipment.slotMapping.Add("ExosuitModule5", EquipmentType.ExosuitModule);
-                Equipment.slotMapping.Add("ExosuitModule6", EquipmentType.ExosuitModule);
-                Equipment.slotMapping.Add("ExosuitModule7", EquipmentType.ExosuitModule);
-                Equipment.slotMapping.Add("ExosuitModule8", EquipmentType.ExosuitModule);               
-                
+                foreach (string slotID in SlotHelper.ExpandedExosuitSlotIDs)
+                    Equipment.slotMapping.Add(slotID, EquipmentType.ExosuitModule);
+
                 Debug.Log("[SlotExtender] Equipment.slotMapping Patched!");
                 SlotMappingExpanded = true;
             }


### PR DESCRIPTION
Initialize_uGUI
- Slot positions now named constants to better explain which slot is positioned where on screen
- New layout for the Seamoth slots
- Added early exit conditions to patching code where applicable
- Removed length on substrings so we have the option to have more than 9 numbered slots
- Removed trailing whitespace

SlotExtender
- Reduced code nesting and added early exit conditions in code where applicable
- Removed redundant slotID definitions. All slotID names are now defined in SlotHelper
- Removed trailing whitespace

SlotHelper
- No more duplication of slotID names
- All slotID names are defined in a single array per vehicle
- NewSeamothSlotIDs and NewExosuitSlotIDs now handled by SlotHelper as an IEnumerable