### PR TITLE
UpgradeHandlerRegistering

### DIFF
--- a/CyclopsLaserCannon/CannonControl.cs
+++ b/CyclopsLaserCannon/CannonControl.cs
@@ -3,6 +3,9 @@ using UnityEngine;
 using UWE;
 using static Common.Modules;
 using static Common.GameHelper;
+using MoreCyclopsUpgrades.CyclopsUpgrades;
+using MoreCyclopsUpgrades.Managers;
+using Common;
 
 namespace CyclopsLaserCannonModule
 {
@@ -30,17 +33,15 @@ namespace CyclopsLaserCannonModule
         private GameObject targetGameobject;        
         private Vector3 targetPosition;                
         private float idleTimer = 3f;
+        private UpgradeHandler upgradeHandler;
 
         public void Start()
         {
+            UpgradeManager.UpgradeManagerInitializing += RegisterUpgrade;
+
             Instance = this;
 
             Main.onConfigurationChanged.AddHandler(this, new Event<string>.HandleFunction(OnConfigurationChanged));
-            Main.onFinishedUpgrades += OnFinishedUpgrades;
-
-            //Main.isAllowedToAdd += IsAllowedToAdd;
-            ///Main.isAllowedToRemove += IsAllowedToRemove;
-            Main.onClearUpgrades += OnClearUpgrades;           
 
             This_Cyclops_Root = transform.parent.gameObject;  
                                     
@@ -67,13 +68,36 @@ namespace CyclopsLaserCannonModule
             Player.main.currentSubChangedEvent.AddHandler(this, new Event<SubRoot>.HandleFunction(OnSubRootChanged));            
         }        
 
+        private void RegisterUpgrade()
+        {            
+            if (upgradeHandler == null)
+            {
+                SNLogger.Log($"[CyclopsLaserCannonModule] Prevented duplicate registration for CannonControl {GetInstanceID()}");
+                return; // already registered
+            }
+
+            SNLogger.Log($"[CyclopsLaserCannonModule] Registering OneTimeUseeHandlerCreator for CannonControl {GetInstanceID()}");
+            UpgradeManager.RegisterOneTimeUseHandlerCreator(() =>
+            {
+                SNLogger.Log($"[CyclopsLaserCannonModule] Upgrade registered for CannonControl {GetInstanceID()}");
+                upgradeHandler = new UpgradeHandler(CannonPrefab.TechTypeID)
+                {
+                    MaxCount = 1,
+                    OnUpgradeCounted = EnableCannonOnUpgradeCounted,
+                    OnClearUpgrades = DisableCannonOnClearUpgrades,                    
+                };
+
+                return upgradeHandler;
+            });
+        }
+
         public void OnDestroy()
         {           
             Player.main.playerModeChanged.RemoveHandler(this, OnPlayerModeChanged);
-            Player.main.currentSubChangedEvent.RemoveHandler(this, OnSubRootChanged);                       
-                        
-            Main.onFinishedUpgrades -= OnFinishedUpgrades;            
+            Player.main.currentSubChangedEvent.RemoveHandler(this, OnSubRootChanged);
 
+            upgradeHandler.OnUpgradeCounted = null;
+            upgradeHandler.OnClearUpgrades = null;
             Destroy(cannon_base_right);
             Destroy(cannon_base_left);
             Destroy(camera_instance);

--- a/CyclopsLaserCannon/CannonHandlers.cs
+++ b/CyclopsLaserCannon/CannonHandlers.cs
@@ -15,32 +15,16 @@
             Button_Cannon.SetActive(value);
         }
 
-        private void EnableCannon()
+        private void EnableCannonOnUpgradeCounted(SubRoot cyclops, Equipment modules, string slot)
         {
-            isModuleInserted = true;
-            LaserCannonSetActive(true);            
+            isModuleInserted = upgradeHandler.Count > 0;
+            LaserCannonSetActive(isModuleInserted);
         }
 
-        private void DisableCannon()
+        private void DisableCannonOnClearUpgrades(SubRoot cyclops)
         {
             isModuleInserted = false;
             LaserCannonSetActive(false);            
-        }
-
-        private void OnClearUpgrades(SubRoot cyclops)
-        {
-            if (cyclops == subroot)
-            {
-                DisableCannon();
-            }
-        }
-
-        private void OnFinishedUpgrades(SubRoot cyclops)
-        {
-            if (cyclops == subroot && Main.upgradeHandler.techType == CannonPrefab.TechTypeID)
-            {                
-                EnableCannon();                              
-            }
         }
 
         private void OnConfigurationChanged(string configToChange)
@@ -75,31 +59,5 @@
                 isActive = false;
             }            
         }
-        
-        /*
-        private bool IsAllowedToAdd(SubRoot subRoot, Pickupable pickupable, bool verbose)
-        {
-            if (isModuleInserted && pickupable.GetTechType() == CannonPrefab.TechTypeID)
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        }
-
-        private bool IsAllowedToRemove(SubRoot subRoot, Pickupable pickupable, bool verbose)
-        {
-            if (isModuleInserted && pickupable.GetTechType() == CannonPrefab.TechTypeID)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        */
     }
 }

--- a/CyclopsLaserCannon/Main.cs
+++ b/CyclopsLaserCannon/Main.cs
@@ -6,9 +6,6 @@ using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 using Common;
 using UWE;
-using MoreCyclopsUpgrades.Managers;
-using MoreCyclopsUpgrades.CyclopsUpgrades;
-
 using static Common.GameHelper;
 using SMLHelper.V2.Utility;
 
@@ -21,12 +18,6 @@ namespace CyclopsLaserCannonModule
         public static Sprite buttonSprite;
 
         public static bool isAssetsLoaded;
-        public static UpgradeHandler upgradeHandler;
-        //Used MCU Events
-        public static UpgradeEvent onFinishedUpgrades;
-        //public static UpgradeAllowedEvent isAllowedToAdd;
-        //public static UpgradeAllowedEvent isAllowedToRemove;
-        public static UpgradeEvent onClearUpgrades;
 
         public static Event<string> onConfigurationChanged = new Event<string>();
 
@@ -49,27 +40,6 @@ namespace CyclopsLaserCannonModule
             catch (Exception ex)
             {
                 Debug.LogException(ex);
-            }
-
-            try
-            {
-                UpgradeManager.RegisterReusableHandlerCreator(() =>
-                {
-                    upgradeHandler = new UpgradeHandler(CannonPrefab.TechTypeID)
-                    {
-                        MaxCount = 1,
-                        //IsAllowedToAdd = isAllowedToAdd,
-                        //IsAllowedToRemove = isAllowedToRemove,
-                        OnFinishedUpgrades = onFinishedUpgrades,
-                        OnClearUpgrades = onClearUpgrades
-                    };
-
-                    return upgradeHandler;
-                });
-            }
-            catch
-            {
-                SNLogger.Log("[CyclopsLaserCannonModule] MCU UpgradeManager initialization failed!");
             }
         }
 

--- a/CyclopsLaserCannon/Patch/CyclopsExternalCams_Start_Patch.cs
+++ b/CyclopsLaserCannon/Patch/CyclopsExternalCams_Start_Patch.cs
@@ -7,19 +7,15 @@ namespace CyclopsLaserCannonModule.Patch
     [HarmonyPatch("Start")]
     public class CyclopsExternalCams_Start_Patch
     {
-        private static bool isPatched = false;
-
         [HarmonyPostfix]
         public static void Postfix(CyclopsExternalCams __instance)
         {
-            if (isPatched)
-                return;
+            if (__instance.gameObject.GetComponent<CannonControl>() == null)
+            {
+                __instance.gameObject.AddComponent<CannonControl>();
 
-            __instance.gameObject.AddOrGetComponent<CannonControl>();           
-
-            SNLogger.Log("[CyclopsLaserCannonModule] CyclopsExternalCams patched. CannonControl component added.");
-
-            isPatched = true;
+                SNLogger.Log($"[CyclopsLaserCannonModule] CyclopsExternalCams patched on CyclopsExternalCams {__instance.gameObject.GetInstanceID()}. CannonControl component added.");
+            }
         }
     }    
 }


### PR DESCRIPTION
## Correction made to usage of MCU UpgradeHandler
- Removes need for static event handlers
- Ensures that each new CyclopsExternalCams object gets patched, not just the first one
- The CannonControl monobehavior now holds a reference to its own upgradeHandler
---
While this is currently untested (because I don't have all the files needed to fully compile the project),  
I know the upgrade handler code well enough to confidently say that this should work.