### PR TITLE
Revert "UpgradeHandlerRegistering - Correction made to usage of MCU U…

### DIFF
--- a/CyclopsLaserCannon/CannonHandlers.cs
+++ b/CyclopsLaserCannon/CannonHandlers.cs
@@ -15,16 +15,32 @@
             Button_Cannon.SetActive(value);
         }
 
-        private void EnableCannonOnUpgradeCounted(SubRoot cyclops, Equipment modules, string slot)
+        private void EnableCannon()
         {
-            isModuleInserted = upgradeHandler.Count > 0;
-            LaserCannonSetActive(isModuleInserted);
+            isModuleInserted = true;
+            LaserCannonSetActive(true);            
         }
 
-        private void DisableCannonOnClearUpgrades(SubRoot cyclops)
+        private void DisableCannon()
         {
             isModuleInserted = false;
             LaserCannonSetActive(false);            
+        }
+
+        private void OnClearUpgrades(SubRoot cyclops)
+        {
+            if (cyclops == subroot)
+            {
+                DisableCannon();
+            }
+        }
+
+        private void OnFinishedUpgrades(SubRoot cyclops)
+        {
+            if (cyclops == subroot && Main.upgradeHandler.techType == CannonPrefab.TechTypeID)
+            {                
+                EnableCannon();                              
+            }
         }
 
         private void OnConfigurationChanged(string configToChange)
@@ -59,5 +75,31 @@
                 isActive = false;
             }            
         }
+        
+        /*
+        private bool IsAllowedToAdd(SubRoot subRoot, Pickupable pickupable, bool verbose)
+        {
+            if (isModuleInserted && pickupable.GetTechType() == CannonPrefab.TechTypeID)
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
+        private bool IsAllowedToRemove(SubRoot subRoot, Pickupable pickupable, bool verbose)
+        {
+            if (isModuleInserted && pickupable.GetTechType() == CannonPrefab.TechTypeID)
+            {
+                return true;
+            }
+            else
+            {
+                return false;
+            }
+        }
+        */
     }
 }

--- a/CyclopsLaserCannon/Main.cs
+++ b/CyclopsLaserCannon/Main.cs
@@ -6,6 +6,9 @@ using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 using Common;
 using UWE;
+using MoreCyclopsUpgrades.Managers;
+using MoreCyclopsUpgrades.CyclopsUpgrades;
+
 using static Common.GameHelper;
 using SMLHelper.V2.Utility;
 
@@ -18,6 +21,12 @@ namespace CyclopsLaserCannonModule
         public static Sprite buttonSprite;
 
         public static bool isAssetsLoaded;
+        public static UpgradeHandler upgradeHandler;
+        //Used MCU Events
+        public static UpgradeEvent onFinishedUpgrades;
+        //public static UpgradeAllowedEvent isAllowedToAdd;
+        //public static UpgradeAllowedEvent isAllowedToRemove;
+        public static UpgradeEvent onClearUpgrades;
 
         public static Event<string> onConfigurationChanged = new Event<string>();
 
@@ -40,6 +49,27 @@ namespace CyclopsLaserCannonModule
             catch (Exception ex)
             {
                 Debug.LogException(ex);
+            }
+
+            try
+            {
+                UpgradeManager.RegisterReusableHandlerCreator(() =>
+                {
+                    upgradeHandler = new UpgradeHandler(CannonPrefab.TechTypeID)
+                    {
+                        MaxCount = 1,
+                        //IsAllowedToAdd = isAllowedToAdd,
+                        //IsAllowedToRemove = isAllowedToRemove,
+                        OnFinishedUpgrades = onFinishedUpgrades,
+                        OnClearUpgrades = onClearUpgrades
+                    };
+
+                    return upgradeHandler;
+                });
+            }
+            catch
+            {
+                SNLogger.Log("[CyclopsLaserCannonModule] MCU UpgradeManager initialization failed!");
             }
         }
 

--- a/CyclopsLaserCannon/Patch/CyclopsExternalCams_Start_Patch.cs
+++ b/CyclopsLaserCannon/Patch/CyclopsExternalCams_Start_Patch.cs
@@ -7,15 +7,19 @@ namespace CyclopsLaserCannonModule.Patch
     [HarmonyPatch("Start")]
     public class CyclopsExternalCams_Start_Patch
     {
+        private static bool isPatched = false;
+
         [HarmonyPostfix]
         public static void Postfix(CyclopsExternalCams __instance)
         {
-            if (__instance.gameObject.GetComponent<CannonControl>() == null)
-            {
-                __instance.gameObject.AddComponent<CannonControl>();
+            if (isPatched)
+                return;
 
-                SNLogger.Log($"[CyclopsLaserCannonModule] CyclopsExternalCams patched on CyclopsExternalCams {__instance.gameObject.GetInstanceID()}. CannonControl component added.");
-            }
+            __instance.gameObject.AddOrGetComponent<CannonControl>();           
+
+            SNLogger.Log("[CyclopsLaserCannonModule] CyclopsExternalCams patched. CannonControl component added.");
+
+            isPatched = true;
         }
     }    
 }


### PR DESCRIPTION
…pgradeHandler - Removes need for static event handlers - Ensures that each new CyclopsExternalCams object gets patched, not just the first one - The CannonControl monobehavior now holds a reference to its own upgradeHandler"

This reverts commit 41130b8aa883403207870de35e3d4dfc29cc2d34.