### PR TITLE
Circle layout for slots

### DIFF
--- a/SlotExtender/Configuration/SEConfig.cs
+++ b/SlotExtender/Configuration/SEConfig.cs
@@ -23,6 +23,7 @@ namespace SlotExtender.Configuration
         internal static int MAXSLOTS;
         public static Color TEXTCOLOR;
         internal static int STORAGE_SLOTS_OFFSET = 4;
+        internal static int SLOT_LAYOUT = 0; // 0 - grid, 1 - circle
 
         private static readonly string[] SECTIONS =
         {
@@ -51,6 +52,7 @@ namespace SlotExtender.Configuration
             "MaxSlots",
             "TextColor",
             "SeamothStorageSlotsOffset",
+            "SlotLayout"
         };
 
         private static readonly List<ConfigData> DEFAULT_CONFIG = new List<ConfigData>
@@ -58,6 +60,7 @@ namespace SlotExtender.Configuration
             new ConfigData(SECTIONS[1], SECTION_Settings[0], 12.ToString()),
             new ConfigData(SECTIONS[1], SECTION_Settings[1], COLORS.Green.ToString()),
             new ConfigData(SECTIONS[1], SECTION_Settings[2], 4.ToString()),
+            new ConfigData(SECTIONS[1], SECTION_Settings[3], "Circle"),
             new ConfigData(SECTIONS[0], SECTION_Hotkeys[0], InputHelper.GetKeyCodeAsInputName(KeyCode.T)),
             new ConfigData(SECTIONS[0], SECTION_Hotkeys[1], InputHelper.GetKeyCodeAsInputName(KeyCode.R)),
             new ConfigData(SECTIONS[0], SECTION_Hotkeys[2], InputHelper.GetKeyCodeAsInputName(KeyCode.Alpha6)),
@@ -130,6 +133,8 @@ namespace SlotExtender.Configuration
                     STORAGE_SLOTS_OFFSET = result < 3? 0: result > 8? 8: result;
                 }
 
+                SLOT_LAYOUT = Helper.GetKeyValue(FILENAME, SECTIONS[1], SECTION_Settings[3]) == "Circle"? 1: 0;
+
                 SNLogger.Log("SlotExtender", "Configuration loaded.");
             }
             catch
@@ -168,6 +173,7 @@ namespace SlotExtender.Configuration
             Helper.SetKeyValue(FILENAME, SECTIONS[1], SECTION_Settings[0], MAXSLOTS.ToString());
             Helper.SetKeyValue(FILENAME, SECTIONS[1], SECTION_Settings[1], Modules.GetColorName(TEXTCOLOR));
             Helper.SetKeyValue(FILENAME, SECTIONS[1], SECTION_Settings[2], STORAGE_SLOTS_OFFSET.ToString());
+            Helper.SetKeyValue(FILENAME, SECTIONS[1], SECTION_Settings[3], SLOT_LAYOUT == 0? "Grid": "Circle");
 
             SNLogger.Log("SlotExtender", "Configuration saved.");
         }

--- a/SlotExtender/Patches/uGUI_Equipment_Patch.cs
+++ b/SlotExtender/Patches/uGUI_Equipment_Patch.cs
@@ -14,7 +14,7 @@ namespace SlotExtender.Patches
         [HarmonyPrefix]
         internal static void Prefix(uGUI_Equipment __instance)
         {
-           __instance.gameObject.AddIfNeedComponent<Initialize_uGUI>();            
+           __instance.gameObject.AddIfNeedComponent<Initialize_uGUI>();
         }
 
         [HarmonyPostfix]
@@ -22,7 +22,7 @@ namespace SlotExtender.Patches
         {
             var allSlots = (Dictionary<string, uGUI_EquipmentSlot>)__instance.GetPrivateField("allSlots", BindingFlags.SetField);
 
-            Initialize_uGUI.Instance.Add_uGUIslots(__instance, allSlots);            
+            Initialize_uGUI.Instance.Add_uGUIslots(__instance, allSlots);
         }
     }
     */
@@ -36,60 +36,47 @@ namespace SlotExtender.Patches
         {
             GameObject Equipment = __instance.gameObject;
 
-            GameObject SeamothModule1 = Equipment.FindChild("SeamothModule1");
-            GameObject SeamothModule2 = Equipment.FindChild("SeamothModule2");
-            GameObject ExosuitModule2 = Equipment.FindChild("ExosuitModule2");
+            void _setSlotPos(GameObject slot, Vector2 pos)
+            {
+                slot.GetComponent<uGUI_EquipmentSlot>().rectTransform.anchoredPosition = pos;
+            }
+
+            void _processBaseSlot(SlotData slotData)
+            {
+                _setSlotPos(Equipment.FindChild(slotData.SlotID), slotData.SlotPOS);
+            }
+
+            void _processNewSlot(SlotData slotData, GameObject prefab)
+            {
+                GameObject temp_slot = Object.Instantiate(prefab, Equipment.transform, false);
+                temp_slot.name = slotData.SlotID;
+
+                _setSlotPos(temp_slot, slotData.SlotPOS);
+                temp_slot.GetComponent<uGUI_EquipmentSlot>().slot = slotData.SlotID;
+            }
+
+            GameObject SeamothModule = Equipment.FindChild("SeamothModule2");
+            GameObject ExosuitModule = Equipment.FindChild("ExosuitModule2");
             GameObject ExosuitArmLeft = Equipment.FindChild("ExosuitArmLeft");
             GameObject ExosuitArmRight = Equipment.FindChild("ExosuitArmRight");
 
-            foreach (SlotData baseExoSlotData in SlotHelper.BaseExosuitSlotsData)
-            {
-                GameObject temp_slot = Equipment.FindChild(baseExoSlotData.SlotID);
-                uGUI_EquipmentSlot temp_slot_uGUI = temp_slot.GetComponent<uGUI_EquipmentSlot>();
-                temp_slot_uGUI.rectTransform.anchoredPosition = baseExoSlotData.SlotPOS;
-            }
+            // processing exosuit slots
+            SlotHelper.BaseExosuitSlotsData.ForEach(slotData => _processBaseSlot(slotData));
+            SlotHelper.NewExosuitSlotsData.ForEach(slotData => _processNewSlot(slotData, ExosuitModule));
 
-            foreach (SlotData newExoSlotData in SlotHelper.NewExosuitSlotsData)
-            {
-                GameObject temp_slot = Object.Instantiate(ExosuitModule2, Equipment.transform, false);
-                temp_slot.name = newExoSlotData.SlotID;
-                uGUI_EquipmentSlot temp_slot_uGUI = temp_slot.GetComponent<uGUI_EquipmentSlot>();
-                temp_slot_uGUI.slot = newExoSlotData.SlotID;
-                temp_slot_uGUI.rectTransform.anchoredPosition = newExoSlotData.SlotPOS;
-            }
+            _setSlotPos(ExosuitArmLeft, SlotHelper.NewSeamothArmSlotsData[0].SlotPOS);
+            _setSlotPos(ExosuitArmRight, SlotHelper.NewSeamothArmSlotsData[1].SlotPOS);
 
-            uGUI_EquipmentSlot exosuitArmLeft = ExosuitArmLeft.GetComponent<uGUI_EquipmentSlot>();
-            exosuitArmLeft.rectTransform.anchoredPosition = SlotHelper.NewSeamothArmSlotsData[0].SlotPOS;
+            Equipment.transform.Find("ExosuitModule1/Exosuit").localPosition = SlotHelper.vehicleImgPos;
 
-            uGUI_EquipmentSlot exosuitArmRight = ExosuitArmRight.GetComponent<uGUI_EquipmentSlot>();
-            exosuitArmRight.rectTransform.anchoredPosition = SlotHelper.NewSeamothArmSlotsData[1].SlotPOS;
+            // processing seamoth slots
+            SlotHelper.BaseSeamothSlotsData.ForEach(slotData => _processBaseSlot(slotData));
+            SlotHelper.NewSeamothSlotsData.ForEach(slotData => _processNewSlot(slotData, SeamothModule));
 
-            SeamothModule1.FindChild("Seamoth").transform.localPosition = SlotHelper.slotPos[11];
+            _processNewSlot(SlotHelper.NewSeamothArmSlotsData[0], ExosuitArmLeft);
+            _processNewSlot(SlotHelper.NewSeamothArmSlotsData[1], ExosuitArmRight);
 
-            foreach (SlotData baseSeamothSlotData in SlotHelper.BaseSeamothSlotsData)
-            {
-                GameObject temp_slot = Equipment.FindChild(baseSeamothSlotData.SlotID);
-                uGUI_EquipmentSlot temp_slot_uGUI = temp_slot.GetComponent<uGUI_EquipmentSlot>();
-                temp_slot_uGUI.rectTransform.anchoredPosition = baseSeamothSlotData.SlotPOS;
-            }
-
-            foreach (SlotData newSeamothSlotData in SlotHelper.NewSeamothSlotsData)
-            {
-                GameObject temp_slot = Object.Instantiate(SeamothModule2, Equipment.transform, false);
-                temp_slot.name = newSeamothSlotData.SlotID;
-                uGUI_EquipmentSlot temp_slot_uGUI = temp_slot.GetComponent<uGUI_EquipmentSlot>();
-                temp_slot_uGUI.slot = newSeamothSlotData.SlotID;
-                temp_slot_uGUI.rectTransform.anchoredPosition = newSeamothSlotData.SlotPOS;
-            }
-
-            foreach (SlotData armSlotData in SlotHelper.NewSeamothArmSlotsData)
-            {
-                GameObject temp_slot = Object.Instantiate(ExosuitArmLeft, Equipment.transform, false);
-                temp_slot.name = armSlotData.SlotID;
-                uGUI_EquipmentSlot temp_slot_uGUI = temp_slot.GetComponent<uGUI_EquipmentSlot>();
-                temp_slot_uGUI.slot = armSlotData.SlotID;
-                temp_slot_uGUI.rectTransform.anchoredPosition = armSlotData.SlotPOS;
-            }
+            Equipment.transform.Find("SeamothModule1/Seamoth").localPosition = SlotHelper.vehicleImgPos;
 
             SNLogger.Log("SlotExtender", "uGUI_Equipment Slots Patched!");
         }

--- a/SlotExtender/Patches/uGUI_Equipment_Patch.cs
+++ b/SlotExtender/Patches/uGUI_Equipment_Patch.cs
@@ -73,8 +73,11 @@ namespace SlotExtender.Patches
             SlotHelper.BaseSeamothSlotsData.ForEach(slotData => _processBaseSlot(slotData));
             SlotHelper.NewSeamothSlotsData.ForEach(slotData => _processNewSlot(slotData, SeamothModule));
 
-            _processNewSlot(SlotHelper.NewSeamothArmSlotsData[0], ExosuitArmLeft);
-            _processNewSlot(SlotHelper.NewSeamothArmSlotsData[1], ExosuitArmRight);
+            if (RefHelp.IsNamespaceExists("SeamothArms"))
+            {
+                _processNewSlot(SlotHelper.NewSeamothArmSlotsData[0], ExosuitArmLeft);
+                _processNewSlot(SlotHelper.NewSeamothArmSlotsData[1], ExosuitArmRight);
+            }
 
             Equipment.transform.Find("SeamothModule1/Seamoth").localPosition = SlotHelper.vehicleImgPos;
 

--- a/SlotExtender/SlotHelper.cs
+++ b/SlotExtender/SlotHelper.cs
@@ -263,36 +263,21 @@ namespace SlotExtender
                 */
             }
         }
-        
+
         internal static void InitSlotIDs()
         {
-
 #if DEBUG
             SNLogger.Debug("SlotExtender", "Method call: SlotHelper.InitSlotIDs()");
 #endif 
-            SessionSeamothSlotIDs = (string[])Array.CreateInstance(typeof(string), SEConfig.MAXSLOTS + 2);
-            SessionExosuitSlotIDs = (string[])Array.CreateInstance(typeof(string), SEConfig.MAXSLOTS + 2);
+            bool addSeamothArms = RefHelp.IsNamespaceExists("SeamothArms");
 
-            for (int i = 0; i < SEConfig.MAXSLOTS + 2; i++)
-            {
-                if (i == SEConfig.MAXSLOTS)
-                {
-                    SessionSeamothSlotIDs[i] = ExpandedSeamothSlotIDs[12];
-                }
-                else if (i == SEConfig.MAXSLOTS + 1)
-                {
-                    SessionSeamothSlotIDs[i] = ExpandedSeamothSlotIDs[13];
-                }
-                else
-                {
-                    SessionSeamothSlotIDs[i] = ExpandedSeamothSlotIDs[i];
-                }
-            }
+            SessionSeamothSlotIDs = new string[SEConfig.MAXSLOTS + (addSeamothArms? 2: 0)];
+            Array.Copy(ExpandedSeamothSlotIDs, SessionSeamothSlotIDs, SEConfig.MAXSLOTS);
+            if (addSeamothArms)
+                Array.Copy(ExpandedSeamothSlotIDs, 12, SessionSeamothSlotIDs, SEConfig.MAXSLOTS, 2);
 
-            for (int i = 0; i < SEConfig.MAXSLOTS + 2; i++)
-            {                
-                SessionExosuitSlotIDs[i] = ExpandedExosuitSlotIDs[i];
-            } 
+            SessionExosuitSlotIDs = new string[SEConfig.MAXSLOTS + 2];
+            Array.Copy(ExpandedExosuitSlotIDs, SessionExosuitSlotIDs, SEConfig.MAXSLOTS + 2);
         }
 
         internal static void ExpandSlotMapping()

--- a/SlotExtender/SlotHelper.cs
+++ b/SlotExtender/SlotHelper.cs
@@ -35,39 +35,88 @@ namespace SlotExtender
 
         private const float Unit = 200f;
         private const float RowStep = Unit * 2.2f / 3;
-        private const float TopRow = Unit;
-        private const float SecondRow = TopRow - RowStep;
-        private const float ThirdRow = SecondRow - RowStep;
-        private const float FourthRow = ThirdRow - RowStep;
-        private const float FifthRow = FourthRow - RowStep;
-        private const float CenterColumn = 0f;
-        private const float RightColumn = RowStep;
-        private const float LeftColumn = -RowStep;
-        
-        public static readonly Vector2[] slotPos = new Vector2[12]
+
+        private static class SlotPosGrid
         {
-            new Vector2(LeftColumn, TopRow), //slot 1
-            new Vector2(CenterColumn, TopRow),  //slot 2
-            new Vector2(RightColumn, TopRow),   //slot 3
+            private const float TopRow = Unit;
+            private const float SecondRow = TopRow - RowStep;
+            private const float ThirdRow = SecondRow - RowStep;
+            private const float FourthRow = ThirdRow - RowStep;
+            private const float FifthRow = FourthRow - RowStep;
+            private const float CenterColumn = 0f;
+            private const float RightColumn = RowStep;
+            private const float LeftColumn = -RowStep;
 
-            new Vector2(LeftColumn, SecondRow),  //slot 4
-            new Vector2(CenterColumn, SecondRow), //slot 5
-            new Vector2(RightColumn, SecondRow),   //slot 6
+            public static readonly Vector2[] slotPos = new Vector2[12]
+            {
+                new Vector2(LeftColumn, TopRow), //slot 1
+                new Vector2(CenterColumn, TopRow),  //slot 2
+                new Vector2(RightColumn, TopRow),   //slot 3
 
-            new Vector2(LeftColumn, ThirdRow),  //slot 7
-            new Vector2(CenterColumn, ThirdRow),  //slot 8
-            new Vector2(RightColumn, ThirdRow),   //slot 9
+                new Vector2(LeftColumn, SecondRow),  //slot 4
+                new Vector2(CenterColumn, SecondRow), //slot 5
+                new Vector2(RightColumn, SecondRow),   //slot 6
 
-            new Vector2(LeftColumn, FourthRow),   //slot 10
-            new Vector2(CenterColumn, FourthRow),  //slot 11
-            new Vector2(RightColumn, FourthRow)  //slot 12
-        };
+                new Vector2(LeftColumn, ThirdRow),  //slot 7
+                new Vector2(CenterColumn, ThirdRow),  //slot 8
+                new Vector2(RightColumn, ThirdRow),   //slot 9
 
-        private static readonly Vector2[] armSlotPos = new Vector2[2]
+                new Vector2(LeftColumn, FourthRow),   //slot 10
+                new Vector2(CenterColumn, FourthRow),  //slot 11
+                new Vector2(RightColumn, FourthRow)  //slot 12
+            };
+
+            public static readonly Vector2[] armSlotPos = new Vector2[2]
+            {
+                new Vector2(LeftColumn, FifthRow), //arm slot left
+                new Vector2(RightColumn, FifthRow) //arm slot right
+            };
+
+            public static Vector2 vehicleImgPos => slotPos[11];
+        }
+
+        private static class SlotPosCircle
         {
-            new Vector2(LeftColumn, FifthRow), //arm slot left
-            new Vector2(RightColumn, FifthRow) //arm slot right
-        };
+            private const float row1 = Unit;
+            private const float row2 = row1 - RowStep * 3f;
+            private const float row3 = row1 - RowStep * 3.97f;
+            private const float rowhalf = RowStep * 0.5f;
+
+            private const float col1 = -RowStep * 1.5f;
+            private const float col2 = -RowStep * 0.5f;
+            private const float col3 =  RowStep * 0.5f;
+            private const float col4 =  RowStep * 1.5f;
+
+            public static readonly Vector2[] slotPos = new Vector2[12]
+            {
+                new Vector2(col1, row1 - rowhalf), // slot 1
+                new Vector2(col2, row1),           // slot 2
+                new Vector2(col3, row1),           // slot 3
+                new Vector2(col4, row1 - rowhalf), // slot 4
+
+                new Vector2(col1, row2 + rowhalf), // slot 5
+                new Vector2(col2, row2),           // slot 6
+                new Vector2(col3, row2),           // slot 7
+                new Vector2(col4, row2 + rowhalf), // slot 8
+
+                new Vector2(col1, row3), // slot 9
+                new Vector2(col2, row3), // slot 10
+                new Vector2(col3, row3), // slot 11
+                new Vector2(col4, row3)  // slot 12
+            };
+
+            public static readonly Vector2[] armSlotPos = new Vector2[2]
+            {
+                new Vector2(col4, -Unit * 0.1f), // arm slot left
+                new Vector2(col1, -Unit * 0.1f)  // arm slot right
+            };
+
+            public static Vector2 vehicleImgPos => new Vector2(col4, -Unit + rowhalf);
+        }
+
+        public  static Vector2[] slotPos => SEConfig.SLOT_LAYOUT == 0? SlotPosGrid.slotPos: SlotPosCircle.slotPos;
+        private static Vector2[] armSlotPos => SEConfig.SLOT_LAYOUT == 0? SlotPosGrid.armSlotPos: SlotPosCircle.armSlotPos;
+        public  static Vector2   vehicleImgPos => SEConfig.SLOT_LAYOUT == 0? SlotPosGrid.vehicleImgPos: SlotPosCircle.vehicleImgPos;
 
         internal static readonly string[] ExpandedSeamothSlotIDs = new string[14]
         {
@@ -75,7 +124,7 @@ namespace SlotExtender
             "SeamothModule2",
             "SeamothModule3",
             "SeamothModule4",
-            // New slots start here            
+            // New slots start here
             "SeamothModule5",
             "SeamothModule6",
             "SeamothModule7",
@@ -192,7 +241,7 @@ namespace SlotExtender
                 }
                 */
             }
-        }        
+        }
 
         internal static IEnumerable<string> NewExosuitSlotIDs
         {
@@ -291,7 +340,7 @@ namespace SlotExtender
 
                 foreach (string slotID in NewExosuitSlotIDs)
                 {
-                    Equipment.slotMapping.Add(slotID, EquipmentType.ExosuitModule);                    
+                    Equipment.slotMapping.Add(slotID, EquipmentType.ExosuitModule);
                 }
 
                 SNLogger.Log($"[{SEConfig.PROGRAM_NAME}] Equipment slot mapping Patched!");


### PR DESCRIPTION
New optional layout for slots (default now).

- param `SlotLayout` is added to `config.txt` (`SLOT_LAYOUT` is added to SEConfig.cs). `SlotLayout` can be "Grid" or "Circle" (`SLOT_LAYOUT` can be 0 or 1).
- slots for seamoth arms now added only if _SeamothArms_ mod is installed.

![slots-layout](https://user-images.githubusercontent.com/53096970/85924847-7e814a00-b89d-11ea-9a07-6dac44ce3cc2.jpg)
